### PR TITLE
Fix variable scope bug in decontX batch processing

### DIFF
--- a/R/decon.R
+++ b/R/decon.R
@@ -603,7 +603,7 @@ setMethod(
     )
 
     estRmat.temp <- calculateNativeMatrix(
-      counts = countsBat,
+      counts = counts[, batch == bat, drop = FALSE],
       theta = res$theta,
       eta = res$eta,
       phi = res$phi,


### PR DESCRIPTION
Fixed error where countsBat variable was referenced outside its scope. After refactoring to use processBatch function, countsBat was defined inside the function but referenced in the aggregation loop outside.

Changed line 606 to use counts[, batch == bat, drop = FALSE] directly instead of the undefined countsBat variable.

Fixes: Error in .decontX(...): object 'countsBat' not found