### PR TITLE
Fix buildModuleDecisionTree to accept SingleCellExperiment input

### DIFF
--- a/man/buildModuleDecisionTree.Rd
+++ b/man/buildModuleDecisionTree.Rd
@@ -4,11 +4,16 @@
 \alias{buildModuleDecisionTree}
 \title{Build decision tree from recursive module splitting}
 \usage{
-buildModuleDecisionTree(celdaList, minL = NULL, maxL = NULL)
+buildModuleDecisionTree(x, altExpName = "featureSubset", minL = NULL, maxL = NULL)
 }
 \arguments{
-\item{celdaList}{A \linkS4class{celdaList} object returned by
-\link{recursiveSplitModule}.}
+\item{x}{Either a \linkS4class{celdaList} object or a
+\linkS4class{SingleCellExperiment} object returned by
+\link{recursiveSplitModule}. If a SingleCellExperiment is provided, the
+celdaList will be extracted from the metadata.}
+
+\item{altExpName}{The name for the \link{altExp} slot
+to use if \code{x} is a SingleCellExperiment. Default "featureSubset".}
 
 \item{minL}{Integer. Minimum number of modules to include in the tree.
 If NULL, uses the minimum L from the celdaList. Default NULL.}

--- a/tests/testthat/test-moduleDecisionTree.R
+++ b/tests/testthat/test-moduleDecisionTree.R
@@ -4,10 +4,10 @@ context("Testing module decision tree functions")
 # Note: These tests require running recursiveSplitModule which can be slow
 # Tests are kept minimal to ensure the basic functionality works
 
-test_that(desc = "buildModuleDecisionTree requires celdaList input", {
+test_that(desc = "buildModuleDecisionTree requires valid input", {
     expect_error(
         buildModuleDecisionTree(matrix(0)),
-        "celdaList must be a 'celdaList' object from recursiveSplitModule"
+        "x must be a 'celdaList' or 'SingleCellExperiment' object"
     )
 })
 
@@ -21,6 +21,19 @@ test_that(desc = "buildModuleDecisionTree requires L parameter", {
     expect_error(
         buildModuleDecisionTree(mockList),
         "celdaList must contain models with L parameter"
+    )
+})
+
+test_that(desc = "buildModuleDecisionTree handles SCE without grid search", {
+    # Create a mock SCE without celda_grid_search in metadata
+    mockSCE <- SingleCellExperiment::SingleCellExperiment(
+        assays = list(counts = matrix(1, nrow = 10, ncol = 10))
+    )
+    SingleCellExperiment::altExp(mockSCE, "featureSubset") <- mockSCE
+
+    expect_error(
+        buildModuleDecisionTree(mockSCE),
+        "No celda_grid_search found in metadata"
     )
 })
 


### PR DESCRIPTION
The recursiveSplitModule() function returns a SingleCellExperiment object with the celdaList stored in metadata, not a direct celdaList object.

Changes:
- Updated buildModuleDecisionTree() to accept both SingleCellExperiment and celdaList objects
- Automatically extracts celdaList from SCE metadata when SCE is provided
- Added altExpName parameter for specifying the altExp slot
- Updated documentation to reflect new signature
- Updated tests to cover both input types

This fixes the error: "celdaList must be a 'celdaList' object from recursiveSplitModule" when passing the direct output of recursiveSplitModule()