### PR TITLE
Fix selectFeatures() parameters to prevent empty rows/columns

### DIFF
--- a/benchmark_optimizations.R
+++ b/benchmark_optimizations.R
@@ -33,8 +33,8 @@ sce <- sim$observedCounts
 sce <- SingleCellExperiment(assays = list(counts = sce))
 
 # Select features (required before running celda_CG)
-# Use minCount=0, minCell=0 to keep all features for this small simulated dataset
-sce <- selectFeatures(sce, minCount = 0, minCell = 0)
+# Use minCount=1, minCell=1 to ensure all features have at least some counts
+sce <- selectFeatures(sce, minCount = 1, minCell = 1)
 
 cat("   - Dataset dimensions:", nrow(sce), "genes x", ncol(sce), "cells\n\n")
 

--- a/benchmark_simple.R
+++ b/benchmark_simple.R
@@ -23,8 +23,8 @@ sim <- simulateContamination(
 sce <- SingleCellExperiment(assays = list(counts = sim$observedCounts))
 
 # Select features (required before running celdaGridSearch)
-# Use minCount=0, minCell=0 to keep all features for this small simulated dataset
-sce <- selectFeatures(sce, minCount = 0, minCell = 0)
+# Use minCount=1, minCell=1 to ensure all features have at least some counts
+sce <- selectFeatures(sce, minCount = 1, minCell = 1)
 
 cat("Dataset:", nrow(sce), "genes x", ncol(sce), "cells\n\n")
 


### PR DESCRIPTION
Changed from minCount=0, minCell=0 to minCount=1, minCell=1 to ensure that all selected features have at least one count. This prevents the validation error: "Each row and column of the count matrix must have at least one count"

Using minCount=1, minCell=1 filters out any genes with all zeros, which is required for celda models to run properly.