### PR TITLE
Add Windows compatibility to benchmark scripts

### DIFF
--- a/benchmark_simple.R
+++ b/benchmark_simple.R
@@ -10,6 +10,17 @@ cat("================================================\n\n")
 
 set.seed(12345)
 
+# Detect OS and set parallel cores accordingly
+# mclapply doesn't work on Windows, so we skip parallel tests on Windows
+isWindows <- .Platform$OS.type == "windows"
+if (isWindows) {
+  cat("NOTE: Windows detected. Parallel tests (nCores > 1) will be skipped.\n")
+  cat("      mclapply() is not supported on Windows.\n\n")
+  parallelCores <- 1
+} else {
+  parallelCores <- 4
+}
+
 # Generate simulated data
 cat("Generating simulated dataset...\n")
 sim <- simulateContamination(
@@ -62,44 +73,53 @@ time_serial <- system.time({
 cat("Total time:", round(time_serial["elapsed"], 2), "seconds\n\n")
 
 # Test 2: Parallel execution
-cat("Test 2: Parallel execution (nCores = 4)\n")
-time_parallel <- system.time({
-  model_parallel <- celdaGridSearch(
-    x = sce,
-    paramsTest = list(L = c(5, 10), K = c(8, 10)),
-    paramsFixed = list(sampleLabel = sim$z),
-    maxIter = 50,
-    nchains = 1,
-    cores = 4,
-    verbose = FALSE,
-    perplexity = FALSE
-  )
+if (!isWindows) {
+  cat("Test 2: Parallel execution (nCores = 4)\n")
+  time_parallel <- system.time({
+    model_parallel <- celdaGridSearch(
+      x = sce,
+      paramsTest = list(L = c(5, 10), K = c(8, 10)),
+      paramsFixed = list(sampleLabel = sim$z),
+      maxIter = 50,
+      nchains = 1,
+      cores = parallelCores,
+      verbose = FALSE,
+      perplexity = FALSE
+    )
 
-  best_parallel <- selectBestModel(model_parallel)
+    best_parallel <- selectBestModel(model_parallel)
 
-  # Test recursive splits with parallelization
-  split_module_parallel <- recursiveSplitModule(
-    x = best_parallel,
-    maxL = 15,
-    nCores = 4,
-    verbose = FALSE
-  )
+    # Test recursive splits with parallelization
+    split_module_parallel <- recursiveSplitModule(
+      x = best_parallel,
+      maxL = 15,
+      nCores = parallelCores,
+      verbose = FALSE
+    )
 
-  split_cell_parallel <- recursiveSplitCell(
-    x = best_parallel,
-    maxK = 15,
-    nCores = 4,
-    verbose = FALSE
-  )
-})
-cat("Total time:", round(time_parallel["elapsed"], 2), "seconds\n\n")
+    split_cell_parallel <- recursiveSplitCell(
+      x = best_parallel,
+      maxK = 15,
+      nCores = parallelCores,
+      verbose = FALSE
+    )
+  })
+  cat("Total time:", round(time_parallel["elapsed"], 2), "seconds\n\n")
+} else {
+  cat("Test 2: Parallel execution SKIPPED (not supported on Windows)\n\n")
+  time_parallel <- time_serial
+}
 
 # Summary
 cat("================================================\n")
 cat("RESULTS:\n")
 cat("  Serial time:", round(time_serial["elapsed"], 2), "seconds\n")
-cat("  Parallel time:", round(time_parallel["elapsed"], 2), "seconds\n")
-cat("  Speedup:", round(time_serial["elapsed"] / time_parallel["elapsed"], 2), "x\n")
+if (!isWindows) {
+  cat("  Parallel time:", round(time_parallel["elapsed"], 2), "seconds\n")
+  cat("  Speedup:", round(time_serial["elapsed"] / time_parallel["elapsed"], 2), "x\n")
+} else {
+  cat("  Parallel tests: SKIPPED (Windows does not support mclapply)\n")
+}
 cat("================================================\n\n")
 
 # Optional: Generate HTML report with parallelization


### PR DESCRIPTION
Added OS detection to skip parallel tests on Windows where mclapply() is not supported. The scripts now:

1. Detect Windows using .Platform$OS.type
2. Skip parallel tests (nCores > 1) on Windows with informative messages
3. Run only serial tests on Windows
4. Run full benchmark suite (serial + parallel) on Unix/Linux/macOS

This prevents the error: "'mc.cores' > 1 is not supported on Windows"

On Windows, users will see which tests are skipped and why. On other platforms, all tests run as before with parallelization.